### PR TITLE
GPIO00/S1 for TTGO-T-DISPLAY

### DIFF
--- a/boards/ttgotdisplay.csv
+++ b/boards/ttgotdisplay.csv
@@ -22,9 +22,9 @@ P_ENC1_BTN,data,u8,5
 P_BTN0_A,data,u8,255
 P_BTN0_B,data,u8,255
 P_BTN0_C,data,u8,255
-P_BTN1_A,data,u8,255
-P_BTN1_B,data,u8,255
-P_BTN1_C,data,u8,255
+P_BTN1_A,data,u8,12
+P_BTN1_B,data,u8,35
+P_BTN1_C,data,u8,0
 P_I2C_SCL,data,u8,16
 P_I2C_SDA,data,u8,5
 P_I2C_RST,data,u8,23
@@ -47,6 +47,8 @@ O_LCD_TYPE,data,u8,204
 O_LCD_ROTA,data,u8,0
 O_LCD_OUT,data,u32,0
 O_DDMM_FLAG,data,u8,0
+O_BTN0,data,u8,0
+O_BTN1,data,u8,0
 
 custom_ir_space,namespace,,
 K_UP,data,string,

--- a/main/ClickButtons.c
+++ b/main/ClickButtons.c
@@ -18,6 +18,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include <driver/i2c.h>
+#include "gpio.h"
 // ----------------------------------------------------------------------------
 
 #define TAG "ClickButton"
@@ -51,17 +52,17 @@ Button_t* ClickButtonsInit(int8_t A, int8_t B, int8_t C, bool Active)
 	gpio_conf.pull_down_en = (enc->pinsActive == LOW) ?GPIO_PULLDOWN_DISABLE : GPIO_PULLDOWN_ENABLE;
 	gpio_conf.intr_type = GPIO_INTR_DISABLE;	
 
-  if (enc->pinBTN[0] > 0) 
+  if (enc->pinBTN[0] != (int8_t) GPIO_NONE)
   {
 	gpio_conf.pin_bit_mask = ((uint64_t)(((uint64_t)1)<<enc->pinBTN[0]));
 	ESP_ERROR_CHECK(gpio_config(&gpio_conf));
   }
-  if (enc->pinBTN[1] > 0) 
+  if (enc->pinBTN[1] != (int8_t) GPIO_NONE)
   {
 	gpio_conf.pin_bit_mask = ((uint64_t)(((uint64_t)1)<<enc->pinBTN[1]));
 	ESP_ERROR_CHECK(gpio_config(&gpio_conf));
   }
-  if (enc->pinBTN[2] > 0) 
+  if (enc->pinBTN[2] != (int8_t) GPIO_NONE)
   {
 	gpio_conf.pin_bit_mask = ((uint64_t)(((uint64_t)1)<<enc->pinBTN[2]));
 	ESP_ERROR_CHECK(gpio_config(&gpio_conf));
@@ -106,7 +107,7 @@ IRAM_ATTR void serviceBtn(Button_t *enc)
   for(uint8_t i = 0; i < 3; i++) 
   {
 //	if (currentMillis < enc->lastButtonCheck[i]) enc->lastButtonCheck[i] = 0;        // Handle case when millis() wraps back around to zero
-	if (enc->pinBTN[i] > 0 )        // check enc->button only, if a pin has been provided
+	if (enc->pinBTN[i] != (int8_t) GPIO_NONE )        // check enc->button only, if a pin has been provided
 //		&& ((currentMillis - enc->lastButtonCheck[i]) >= ENC_BUTTONINTERVAL))            // checking enc->button is sufficient every 10-30ms
 	{ 
 //		enc->lastButtonCheck[i] = currentMillis;
@@ -205,7 +206,7 @@ bool getPinStates(Button_t *enc,uint8_t index) {
   }
   return pinState;
 */  
-  if (enc->pinBTN[index] == 0) return false;
+  if (enc->pinBTN[index] == (int8_t) GPIO_NONE) return false;
   return (enc->expGpio?((rexp >> (enc->pinBTN[index]-1) & 1)):digitalRead(enc->pinBTN[index]));
 }
 

--- a/main/gpio.c
+++ b/main/gpio.c
@@ -459,7 +459,7 @@ void gpio_get_active_buttons(bool *abtn0, bool *abtn1)
 		return;
 	}		 
 	err = nvs_get_u8(hardware_handle, "O_BTN0",(uint8_t *) abtn0);	 
-	err = nvs_get_u8(hardware_handle, "O_BTN1",(uint8_t *) abtn0);	
+	err = nvs_get_u8(hardware_handle, "O_BTN1",(uint8_t *) abtn1);
 	if (err != ESP_OK) ESP_LOGD(TAG,"g_get_active_buttons err 0x%x",err);
 	
 	close_partition(hardware_handle,hardware);			


### PR DESCRIPTION
Problem description.
A.- Board: TTGO-T-DISPLAY. Sw version: git as of Feb. 26th 2021.
B.- Use case: to control stations +/- with on-board buttons S1 & S2 (i.e., pins GPIO00 & GPIO35 configured as inputs with GPIO_PULLUP_ENABLE).
C.- Modified ttgotdisplay.csv and flashed: 
D.- Result: Button S2 (GPIO35) moves to next station in the list, as expected. Button S1 (GPIO00) is not responsive (GPIO00 is never configured).
E.- Proposed solution. Tested and working:
1.- Changes in file ClickButtons.c (see below).
2.- Changes in file gpio.c (see below).

Thanks, and keep up the good work.
(And remember when using GPIO00 in your application: it is better to use esptool.py, other tools might mess around with RTS&DTR signals).