### PR TITLE
DeepSleep

### DIFF
--- a/boards/ttgotdisplay.csv
+++ b/boards/ttgotdisplay.csv
@@ -10,10 +10,10 @@ P_MISO,data,u8,2
 P_MOSI,data,u8,19
 P_CLK,data,u8,18
 P_XCS,data,u8,32
-P_RST,data,u8,12
+P_RST,data,u8,15
 P_XDCS,data,u8,33
-P_DREQ,data,u8,34
-P_ENC0_A,data,u8,14
+P_DREQ,data,u8,39
+P_ENC0_A,data,u8,255
 P_ENC0_B,data,u8,17
 P_ENC0_BTN,data,u8,255
 P_ENC1_A,data,u8,255
@@ -22,9 +22,9 @@ P_ENC1_BTN,data,u8,5
 P_BTN0_A,data,u8,255
 P_BTN0_B,data,u8,255
 P_BTN0_C,data,u8,255
-P_BTN1_A,data,u8,12
-P_BTN1_B,data,u8,35
-P_BTN1_C,data,u8,0
+P_BTN1_A,data,u8,2
+P_BTN1_B,data,u8,0
+P_BTN1_C,data,u8,35
 P_I2C_SCL,data,u8,16
 P_I2C_SDA,data,u8,5
 P_I2C_RST,data,u8,23
@@ -41,6 +41,8 @@ P_JOY_1,data,u8,255
 P_LED_GPIO,data,u8,255
 P_ADC_KBD,data,u8,255
 P_BACKLIGHT,data,u8,4
+P_SLEEP,data,u8,255
+P_LEVEL_SLEEP,data,u8,1
 
 option_space,namespace,,
 O_LCD_TYPE,data,u8,204

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -908,6 +908,12 @@ void app_main()
 	
 	copyDeviceSettings(); // copy in the safe partion
 
+	// Configure Deep Sleep start and wakeup options
+	deepSleepConf(); // also called in addon.c
+	// Enter ESP32 Deep Sleep (but not powerdown uninitialized peripherals) when P_SLEEP GPIO is P_LEVEL_SLEEP
+	if (checkDeepSleepInput())
+		esp_deep_sleep_start();
+
 	// led mode
 	if (g_device->options & T_LED)
 		ledStatus = false; // play mode

--- a/main/gpio.c
+++ b/main/gpio.c
@@ -714,3 +714,27 @@ bool gpio_get_ir_key(nvs_handle handle,const char *key, uint32_t *out_value1 , u
 	
 	return ret;
 }
+
+/** Get the GPIO (P_SLEEP) for Deep Sleep power saving mode. */
+/*  Get the level (P_LEVEL_SLEEP) of pin (P_SLEEP) that triggers power saving. */
+void gpio_get_pinSleep(gpio_num_t *pin, bool *aLevel)
+{
+	esp_err_t err;
+	nvs_handle hardware_handle;
+
+	// init defaults from gpio.h
+	*pin = PIN_SLEEP;
+	*aLevel = LEVEL_SLEEP;
+	
+	if (open_partition(hardware, gpio_space, NVS_READONLY, &hardware_handle)!= ESP_OK) {
+		ESP_LOGD(TAG,"buttons");
+		return;
+	}	
+	
+	err = nvs_get_u8(hardware_handle, "P_SLEEP",(uint8_t *) pin);
+	err |= nvs_get_u8(hardware_handle, "P_LEVEL_SLEEP",(uint8_t *) aLevel);	
+		
+	if (err != ESP_OK) ESP_LOGD(TAG,"gpio_get_pinDeepSleep err 0x%x",err);
+
+	close_partition(hardware_handle,hardware);		
+}

--- a/main/include/addon.h
+++ b/main/include/addon.h
@@ -115,4 +115,8 @@ int getBatPercent();
 void* getEncoder(int num);
 struct tm* getDt();
 
+bool deepSleepConf(void);
+bool checkDeepSleepInput(void);
+void deepSleepStart(void);
+
 #endif

--- a/main/include/gpio.h
+++ b/main/include/gpio.h
@@ -62,6 +62,7 @@
 #define PIN_BTN1_B   GPIO_NONE		
 #define PIN_BTN1_C 	 GPIO_NONE		
 
+
 // Joystick (2 buttons emulation on ADC)
 //--------------------------------------
 #define PIN_JOY_0	GPIO_NONE
@@ -104,6 +105,10 @@
 //esplay
 #define PIN_AUDIO_SHDN	GPIO_NUM_4
 
+// Sleep Input. https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/sleep_modes.html 
+//-------------
+#define PIN_SLEEP   GPIO_NONE // 13 . Enter Deep Sleep if pin P_SLEEP is set to P_LEVEL_SLEEP. Only GPIOs which have RTC functionality can be used: 0,2,4,12-15,25-27,32-39. And note that GPIO12 is a bootstrap pin, ESP32 might not even start up if GPIO12 is grounded.
+#define LEVEL_SLEEP   1		  // Level of P_SLEEP to enter Deep Sleep.
 // I2C rda5807 (if lcd is spi)
 // (removed)
 //----------------------------
@@ -149,5 +154,6 @@ void option_set_lcd_stop(uint32_t enca);
 void option_set_lcd_out(uint32_t enca);
 void option_set_lcd_blv(int blv);
 uint8_t gpioToChannel(uint8_t gpio);
+void gpio_get_pinSleep(gpio_num_t *pin, bool *aLevel);
 
 #endif


### PR DESCRIPTION
Enter ESP32 Deep Sleep, and powerdown peripherals, when pin P_SLEEP GPIO is set to P_LEVEL_SLEEP. 
( https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/sleep_modes.html )
Only GPIOs which have RTC functionality can be used: 0,2,4,12-15,25-27,32-39. And note that GPIO12 is a bootstrap pin, ESP32 might not even start up if GPIO12 is grounded.